### PR TITLE
Do not truncate metrics log file on start

### DIFF
--- a/jobs/service-metrics/templates/service_metrics_ctl.erb
+++ b/jobs/service-metrics/templates/service_metrics_ctl.erb
@@ -34,7 +34,7 @@ metrics_log_tag=service-metrics
 metrics_log_file=$log_dir/service-metrics.log
 
 log() {
-  echo "$(date): $*" > $metrics_log_file
+  echo "$(date): $*" >> $script_log_file
 }
 export -f log
 


### PR DESCRIPTION
Also, log from control script to ctl.log, not service-metrics.log

cc: @jamesjoshuahill 
